### PR TITLE
mod (PHP 8.1 upgrade) deprecation errors

### DIFF
--- a/src/Extensions/ProgressiveImageExtension.php
+++ b/src/Extensions/ProgressiveImageExtension.php
@@ -99,7 +99,7 @@ class ProgressiveImageExtension extends Extension
      * @param int $height
      * @param ViewableData $tiny a version of $image that is tiny
      */
-    public function getProgressiveTag(ViewableData $image, $width = null, $height = null, ViewableData $tiny)
+    public function getProgressiveTag(ViewableData $image, $width, $height, ViewableData $tiny)
     {
         if (!$width && !$height) {
             return null;


### PR DESCRIPTION
Fix for PHP 8.1 deprecation errors, optional parameters must come after required parameters.

ProgressiveImageExtension.php
- Remove optional function parameters to fix deprecation errors